### PR TITLE
feat: install requested pypi packages (read file)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,7 @@ if [ "${#}" -eq 0 ] || [ "${1#-}" != "${1}" ]; then
 fi
 
 if [ "${1}" = "sopel" ]; then
+  [ -f "/pypi_packages.txt" ] && su-exec sopel pip install --user -r /pypi_packages.txt
   exec su-exec sopel "${@}"
 fi
 


### PR DESCRIPTION
A user can now mount a file (following pip requirements.txt format) with
packages they would like to be made available to the bot environment. These
packages will be `pip install --user -r ...` on startup.

The file must be mounted to `/pypi_packages.txt` and can contain any
package available from pypi that does not require third-party libraries
(e.g., see the `libenchant` situation with sopel-irc/sopel).