### PR TITLE
fix: install pypi packages one at a time

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,13 @@ if [ "${#}" -eq 0 ] || [ "${1#-}" != "${1}" ]; then
 fi
 
 if [ "${1}" = "sopel" ]; then
-  [ -f "/pypi_packages.txt" ] && su-exec sopel pip install --user -r /pypi_packages.txt
+  if [ -f "/pypi_packages.txt" ]; then
+    cat /pypi_packages.txt | grep -v '^#' | grep -v '^$' | \
+      while read line; do
+        [ "${line}" = "\#*" ] && continue
+        su-exec sopel pip install --user "${line}"
+      done
+  fi
   exec su-exec sopel "${@}"
 fi
 


### PR DESCRIPTION
Install packages sequentially to ensure that dependencies are resolved correctly. Generally, this shouldn't be a problem, but arose due to the issue described in #17.

A side-effect of this fix is that order of package installation can be enforced to be in order of appearance in `/pypi_packages.txt` file.

Fixes #17