### PR TITLE
feat: install request pypi packages (env vars)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,14 +6,29 @@ export PATH="/home/sopel/.local/bin:${PATH}"
 # Define functions
 change_uid () {
   NEW_UID="${1}"
-  echo -n "Setting UID for user sopel to ${NEW_UID}... "
-  (usermod -u "${NEW_UID}" sopel && echo "Done.") || (echo "FAILED!" && return 1)
+  echo -en "\033[44mSetting UID for user sopel to ${NEW_UID}... \033[0m"
+  (usermod -u "${NEW_UID}" sopel && echo -e "\033[92;44mDone.\033[0m") || {
+    RC=$?
+    echo -e "\033[41mFAILED!\033[0m" && return $RC
+  }
 }
 
 change_gid () {
   NEW_GID="${1}"
-  echo -n "Setting GID for user sopel to ${NEW_GID}... "
-  (groupmod -g "${NEW_GID}" sopel && echo "Done.") || (echo "FAILED!" && return 1)
+  echo -en "\033[44mSetting GID for user sopel to ${NEW_GID}... \033[0m"
+  (groupmod -g "${NEW_GID}" sopel && echo -e "\033[92;44mDone.\033[0m") || {
+    RC=$?
+    echo -e "\033[41mFAILED!\033[0m" && return $RC
+  }
+}
+
+install_package () {
+  PACKAGE="${1}"
+  echo -e "\033[44mInstalling package \"${PACKAGE}\" with pip...\033[0m"
+  su-exec sopel pip install --user "${PACKAGE}" || {
+    RC=$?
+    echo -e "\033[41mFAILED!\033[0m" && return $RC
+  }
 }
 
 # Check if IDs need to be changed
@@ -25,19 +40,27 @@ if [ "${#}" -eq 0 ] || [ "${1#-}" != "${1}" ]; then
   set -- sopel "${@}"
 fi
 
+# Run sopel
 if [ "${1}" = "sopel" ]; then
   if [ -f "/pypi_packages.txt" ]; then
     cat /pypi_packages.txt | grep -v '^#' | grep -v '^$' | \
       while read line; do
         [ "${line}" = "\#*" ] && continue
-        su-exec sopel pip install --user "${line}"
+        install_package "${line}"
       done
   fi
+
+  if [ -n "${EXTRA_PYPI_PACKAGES}" ]; then
+    for package in ${EXTRA_PYPI_PACKAGES}; do install_package "${package}"; done
+  fi
+
   exec su-exec sopel "${@}"
 fi
 
+# Run arbitrary command, as specific user
 if [ -n "${USER}" ]; then
   set -- su-exec "${USER}" "${@}"
 fi
 
+# Run arbitrary command, as root
 exec "${@}"


### PR DESCRIPTION
A user can now set the `EXTRA_PYPI_PACKAGES` env var (for docker using
`-e`) with a space-separated list of packages they would like to be made
available to the bot environment. These packages will be `pip install
--user -r ...` on startup, sequentially (see #18).

The env var can contain any package available from pypi that does not
require third-party libraries (e.g., see the `libenchant` situation with
sopel-irc/sopel).