### PR TITLE
feat: allow Alpine Linux packages to be installed on startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,10 +22,19 @@ change_gid () {
   }
 }
 
-install_package () {
+install_pip_package () {
   PACKAGE="${1}"
   echo -e "\033[44mInstalling package \"${PACKAGE}\" with pip...\033[0m"
   su-exec sopel pip install --user "${PACKAGE}" || {
+    RC=$?
+    echo -e "\033[41mFAILED!\033[0m" && return $RC
+  }
+}
+
+install_apk_packages () {
+  PACKAGES="${@}"
+  echo -e "\033[44mInstalling apk packages: ${PACKAGES}...\033[0m"
+  apk add --no-cache ${PACKAGES} || {
     RC=$?
     echo -e "\033[41mFAILED!\033[0m" && return $RC
   }
@@ -42,18 +51,25 @@ fi
 
 # Run sopel
 if [ "${1}" = "sopel" ]; then
+  # Install extra apk packages first to satisfy pip requirements
+  [ -f "/apk_packages.txt" ] && install_apk_packages $(cat /apk_packages.txt | tr $'\n' ' ')
+
+  [ -n "${EXTRA_APK_PACKAGES}" ] && install_apk_packages ${EXTRA_APK_PACKAGES}
+
+  # Install extra pypi packages
   if [ -f "/pypi_packages.txt" ]; then
     cat /pypi_packages.txt | grep -v '^#' | grep -v '^$' | \
       while read line; do
         [ "${line}" = "\#*" ] && continue
-        install_package "${line}"
+        install_pip_package "${line}"
       done
   fi
 
   if [ -n "${EXTRA_PYPI_PACKAGES}" ]; then
-    for package in ${EXTRA_PYPI_PACKAGES}; do install_package "${package}"; done
+    for package in ${EXTRA_PYPI_PACKAGES}; do install_pip_package "${package}"; done
   fi
 
+  # Run sopel
   exec su-exec sopel "${@}"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,7 @@ fi
 # Run sopel
 if [ "${1}" = "sopel" ]; then
   # Install extra apk packages first to satisfy pip requirements
-  [ -f "/apk_packages.txt" ] && install_apk_packages $(cat /apk_packages.txt | tr $'\n' ' ')
+  [ -f "/apk_packages.txt" ] && install_apk_packages $(cat /apk_packages.txt | grep -v '^#' | grep -v '^$' | tr $'\n' ' ')
 
   [ -n "${EXTRA_APK_PACKAGES}" ] && install_apk_packages ${EXTRA_APK_PACKAGES}
 


### PR DESCRIPTION
Similar to the option to install Python packages on startup, users can now install packages through `apk add ...` first.  This will allow Python packages with various system dependencies to be easily used in the image.