### PR TITLE
Update to 7.0.6 Fix with new build time dependency. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG SOPEL_REPO=https://github.com/sopel-irc/sopel.git
 ## Set the specific branch/commit for the source
 # This can be a branch name, release/tag, or even specific commit hash.
 # Set Docker build-arg SOPEL_BRANCH, or replace the default value below.
-ARG SOPEL_BRANCH=v7.0.5
+ARG SOPEL_BRANCH=v7.0.6
 ##
 
 ## Do not modify below this !! ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,9 @@ RUN set -ex \
   && apk add --no-cache \
     shadow \
     su-exec \
-    gcc build-base \
+  && apk add --no-cache --virtual .build-deps \
+    gcc \
+    build-base \
 \
   && addgroup -g ${SOPEL_GID} sopel \
   && adduser -u ${SOPEL_UID} -G sopel -h /home/sopel -s /bin/ash sopel -D \

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN set -ex \
   && su-exec sopel python setup.py install --user \
   && cd .. \
   && rm -rf ./sopel-src \
-  && apk del gcc build-base
+  && apk del .build-deps
 
 VOLUME [ "/home/sopel/.sopel" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG SOPEL_REPO=https://github.com/sopel-irc/sopel.git
 ## Set the specific branch/commit for the source
 # This can be a branch name, release/tag, or even specific commit hash.
 # Set Docker build-arg SOPEL_BRANCH, or replace the default value below.
-ARG SOPEL_BRANCH=v7.0.4
+ARG SOPEL_BRANCH=v7.0.5
 ##
 
 ## Do not modify below this !! ##
@@ -79,6 +79,7 @@ RUN set -ex \
   && apk add --no-cache \
     shadow \
     su-exec \
+    gcc build-base \
 \
   && addgroup -g ${SOPEL_GID} sopel \
   && adduser -u ${SOPEL_UID} -G sopel -h /home/sopel -s /bin/ash sopel -D \
@@ -93,7 +94,8 @@ RUN set -ex \
   && cd ./sopel-src \
   && su-exec sopel python setup.py install --user \
   && cd .. \
-  && rm -rf ./sopel-src
+  && rm -rf ./sopel-src \
+  && apk del gcc build-base
 
 VOLUME [ "/home/sopel/.sopel" ]
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ### First run
 
-* Pull the docker image for the latest Sopel release ([v7.0.4](https://github.com/sopel-irc/sopel/releases/tag/v7.0.4))
+* Pull the docker image for the latest Sopel release ([v7.0.5](https://github.com/sopel-irc/sopel/releases/tag/v7.0.5))
 
     ```console
     $ docker pull sopelirc/sopel:latest

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ### First run
 
-* Pull the docker image for the latest Sopel release ([v7.0.5](https://github.com/sopel-irc/sopel/releases/tag/v7.0.5))
+* Pull the docker image for the latest Sopel release ([v7.0.6](https://github.com/sopel-irc/sopel/releases/tag/v7.0.6))
 
     ```console
     $ docker pull sopelirc/sopel:latest

--- a/hooks/build
+++ b/hooks/build
@@ -8,7 +8,7 @@ set -ex
 # since these two variables should be updated (or atleast checked) together
 # with new sopel versions.
 PYTHON_TAG=${PYTHON_TAG:-3.8-alpine}
-SOPEL_BRANCH=${SOPEL_BRANCH:-v7.0.4}
+SOPEL_BRANCH=${SOPEL_BRANCH:-v7.0.5}
 
 # Prevent cache busting during development builds by allowing build-specific
 # ARGs to be set by environment variables.

--- a/hooks/build
+++ b/hooks/build
@@ -8,7 +8,7 @@ set -ex
 # since these two variables should be updated (or atleast checked) together
 # with new sopel versions.
 PYTHON_TAG=${PYTHON_TAG:-3.8-alpine}
-SOPEL_BRANCH=${SOPEL_BRANCH:-v7.0.5}
+SOPEL_BRANCH=${SOPEL_BRANCH:-v7.0.6}
 
 # Prevent cache busting during development builds by allowing build-specific
 # ARGs to be set by environment variables.

--- a/version-map.txt
+++ b/version-map.txt
@@ -1,2 +1,3 @@
 # List of Sopel versions to build:
+v7.0.5
 v7.0.6

--- a/version-map.txt
+++ b/version-map.txt
@@ -1,4 +1,2 @@
 # List of Sopel versions to build:
-v7.0.0
-v7.0.4
-v7.0.4
+v7.0.5

--- a/version-map.txt
+++ b/version-map.txt
@@ -1,2 +1,2 @@
 # List of Sopel versions to build:
-v7.0.5
+v7.0.6


### PR DESCRIPTION
Requires gcc & build-base to successfully compile yarl at build time.

This appears to be a new dependency only at build time but may be required for non-core modules that require sopel at runtime.
sopel->geoip2->aiohttp->yarl