### PR TITLE
Add single arch build using GHA replacing travis

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,90 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Docker Build and Publish
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  schedule:
+    - cron: '0 0 * * *' # Nightly build
+  pull_request:
+    branches: [ master ] 
+  push:
+    branches: [ master ]
+
+  workflow_dispatch: 
+    
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    env:
+      default_python: "3.9"
+
+    strategy:
+      fail-fast: true
+      matrix:
+        python_images: [3.6,3.7,3.8,3.9]
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      - name: Generate versions
+        uses: HardNorth/github-version-generate@v1.1.1
+        with:
+          version-source: file
+          version-file: Dockerfile
+          version-file-extraction-pattern: '(?<=SOPEL_BRANCH=v).+'
+
+      - name: Inspect Version
+        id: tags
+        env:
+          PYTHON_TAG: ${{ matrix.python_images }}
+          IMAGE: ${{ secrets.IMAGE }}
+          version: ${{ env.RELEASE_VERSION }}
+        run: | 
+          TAGS="${IMAGE}:${version}-py${PYTHON_TAG},${IMAGE}:${version%.*}-py${PYTHON_TAG},${IMAGE}:${version%.*.*}-py${PYTHON_TAG}"
+          if [[ "x${{ matrix.python_images }}" == "x${{ env.default_python }}" ]] && [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAGS="${TAGS},${IMAGE}:${version},${IMAGE}:${version%.*},${IMAGE}:${version%.*.*},${IMAGE}:latest"
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            TAGS="${IMAGE}:${GITHUB_SHA::8},${IMAGE}:nightly"
+          fi
+          echo ::set-output name=tags::${TAGS}
+
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build SOPEL for ${{ matrix.python_images }}
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          build-args: PYTHON_TAG=${{ matrix.python_images }}-alpine
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,11 +13,11 @@ on:
     branches: [ master ]
 
   workflow_dispatch: 
-    
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  build_and_push:
+    name: Build, tag, and push images
     env:
       default_python: "3.9"
 
@@ -60,14 +60,14 @@ jobs:
         id: tags
         env:
           PYTHON_TAG: ${{ matrix.python_images }}
-          IMAGE: ${{ secrets.IMAGE }}
+          IMAGE: ${{ secrets.DOCKER_SOPEL_IMAGE_NAME }}
           version: ${{ env.RELEASE_VERSION }}
         run: | 
           TAGS="${IMAGE}:${version}-py${PYTHON_TAG},${IMAGE}:${version%.*}-py${PYTHON_TAG},${IMAGE}:${version%.*.*}-py${PYTHON_TAG}"
           if [[ "x${{ matrix.python_images }}" == "x${{ env.default_python }}" ]] && [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TAGS="${TAGS},${IMAGE}:${version},${IMAGE}:${version%.*},${IMAGE}:${version%.*.*},${IMAGE}:latest"
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-            TAGS="${IMAGE}:${GITHUB_SHA::8},${IMAGE}:nightly"
+            TAGS="${IMAGE}:nightly"
           fi
           echo ::set-output name=tags::${TAGS}
 
@@ -76,15 +76,29 @@ jobs:
         uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       -
         name: Build SOPEL for ${{ matrix.python_images }}
         uses: docker/build-push-action@v2
+        if: github.event_name != 'schedule'
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
           build-args: PYTHON_TAG=${{ matrix.python_images }}-alpine
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.tags }}
+      -
+        name: Build Nightly SOPEL for ${{ matrix.python_images }}
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'schedule' && matrix.python_images == env.default_python
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            PYTHON_TAG=${{ matrix.python_images }}-alpine
+            SOPEL_BRANCH=master
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.tags.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG SOPEL_REPO=https://github.com/sopel-irc/sopel.git
 ## Set the specific branch/commit for the source
 # This can be a branch name, release/tag, or even specific commit hash.
 # Set Docker build-arg SOPEL_BRANCH, or replace the default value below.
-ARG SOPEL_BRANCH=v7.1.1
+ARG SOPEL_BRANCH=v7.1.2
 ##
 
 ## Do not modify below this !! ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG SOPEL_REPO=https://github.com/sopel-irc/sopel.git
 ## Set the specific branch/commit for the source
 # This can be a branch name, release/tag, or even specific commit hash.
 # Set Docker build-arg SOPEL_BRANCH, or replace the default value below.
-ARG SOPEL_BRANCH=v7.1.2
+ARG SOPEL_BRANCH=v7.1.1
 ##
 
 ## Do not modify below this !! ##

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ See [`EXTRA_APK_PACKAGES` environment variable](#extra_apk_packages).
 
 You can also mount a text file to `/apk_packages.txt` with a list of packages to be installed on startup.
 
+### Nightly Builds
+
+An image based on the master branch of [sopel-irc/sopel](https://github.com/sopel-irc/sopel) is rebuilt each day at 00:00 UTC using the `nightly` tag.
+
 ---
 
 ## Environment Variables


### PR DESCRIPTION
The GHA workflow pulls the version numbers to build from the SOPEL_BRANCH environment variable in the Dockerfile rather than relying on changing it in 3 different places.

Has a matrix build for the different supported python versions with Python 3.9 defaulting to be the "main" release version as the latest tag.

New build-time secrets

- DOCKER_SOPEL_IMAGE_NAME: name of the image to be tagged with (i.e. sopelirc/sopel)
- DOCKER_HUB_USERNAME: Username to login to docker hub with.
- DOCKER_HUB_ACCESS_TOKEN: Access token to authenticate with docker hub.
